### PR TITLE
Recommend Apple Silicon too

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 We recommend using
 
-* For **1B to 3B models**, it's advisable to have at least **NVIDIA T4, 10 Series, or 20 Series GPUs**.
+* For **1B to 3B models**, it's advisable to have at least **NVIDIA T4, 10 Series, or 20 Series GPUs**, or **Apple Silicon** like the M1.
 * For **7B to 13B models**, we recommend using **NVIDIA V100, A100, 30 Series, or 40 Series GPUs**.
 
 We have published benchmarks for these models on https://leaderboard.tabbyml.com for Tabby's users to consider when making trade-offs between quality, licensing, and model size.


### PR DESCRIPTION
I was a bit scared to run Tabby for myself because I don't have an NVIDIA GPU in my system. To my surprise however the StarCoder-3B runs fine. It responds very quick on my M2 Max laptop. The GPU isn't even that great in the M2 Max compared to M3 models. Compared to the M1 Pro it is only 20% faster, according to the Metal benchmarks at https://browser.geekbench.com/mac-benchmarks.

The M2 Pro is about 50% faster than the M3 base model though, but the suggestion I made in this PR is for both the 1B and 3B. 3B feels really easy for the M2 Pro, so the 1B should be easy even for the first M1.

Let me know if there are any benchmarks that I can run.