### PR TITLE
chore: use partition_urls for all models

### DIFF
--- a/meta/models.yaml
+++ b/meta/models.yaml
@@ -6,40 +6,45 @@
     prompt_template: "<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>"
 
   <<: *starcoder-series
-  urls:
-  - https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-1B.Q8_0.gguf
-  - https://modelscope.cn/api/v1/models/TabbyML/StarCoder-1B/repo?FilePath=ggml/q8_0.v2.gguf
-  sha256: 1bb6441486d102db03dac30c82d6b1029ee4f9f5d73f27444fa58cbfcd7cfa0f
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-1B.Q8_0.gguf
+    - https://modelscope.cn/api/v1/models/TabbyML/StarCoder-1B/repo?FilePath=ggml/q8_0.v2.gguf
+    sha256: 1bb6441486d102db03dac30c82d6b1029ee4f9f5d73f27444fa58cbfcd7cfa0f
 
 - name: StarCoder-3B
   provider_url: https://huggingface.co/bigcode/starcoderbase-3b
   <<: *starcoder-series
-  urls:
-  - https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-3B.Q8_0.gguf
-  - https://modelscope.cn/api/v1/models/TabbyML/StarCoder-3B/repo?FilePath=ggml/q8_0.v2.gguf
-  sha256: 9798b7cba84ade7c69ff9f033d60c954e16b18f4d01829993b5fe7e33a49ba81
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-3B.Q8_0.gguf
+    - https://modelscope.cn/api/v1/models/TabbyML/StarCoder-3B/repo?FilePath=ggml/q8_0.v2.gguf
+    sha256: 9798b7cba84ade7c69ff9f033d60c954e16b18f4d01829993b5fe7e33a49ba81
 
 - name: StarCoder-7B
   provider_url: https://huggingface.co/bigcode/starcoderbase-7b
   <<: *starcoder-series
-  urls:
-  - https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-7B.Q8_0.gguf
-  - https://modelscope.cn/api/v1/models/TabbyML/StarCoder-7B/repo?FilePath=ggml/q8_0.v2.gguf
-  sha256: 33dfcc7e216f1a072b4e16cd3bb19a0e55f5874ed319416435c8fc99216b8bfa
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-7B.Q8_0.gguf
+    - https://modelscope.cn/api/v1/models/TabbyML/StarCoder-7B/repo?FilePath=ggml/q8_0.v2.gguf
+    sha256: 33dfcc7e216f1a072b4e16cd3bb19a0e55f5874ed319416435c8fc99216b8bfa
 
 - name: StarCoder2-3B
   provider_url: https://huggingface.co/bigcode/starcoder2-3b
   <<: *starcoder-series
-  urls:
-  - https://huggingface.co/nold/starcoder2-3b-GGUF/resolve/main/starcoder2-3b_Q8_0.gguf
-  sha256: 0499b8d046c56934c9741fd00c6206a5f7ca0eb42b59304ab7f4a20cd2f28ebf
+  partition_urls:
+  - urls:
+    - https://huggingface.co/nold/starcoder2-3b-GGUF/resolve/main/starcoder2-3b_Q8_0.gguf
+    sha256: 0499b8d046c56934c9741fd00c6206a5f7ca0eb42b59304ab7f4a20cd2f28ebf
 
 - name: StarCoder2-7B
   provider_url: https://huggingface.co/bigcode/starcoder2-7b
   <<: *starcoder-series
-  urls:
-  - https://huggingface.co/nold/starcoder2-7b-GGUF/resolve/main/starcoder2-7b_Q8_0.gguf
-  sha256: 72a8a59486cdcc8549e5a17a5c5ec66b6ce5db71a9408a2800985791a40fbff0
+  partition_urls:
+  - urls:
+    - https://huggingface.co/nold/starcoder2-7b-GGUF/resolve/main/starcoder2-7b_Q8_0.gguf
+    sha256: 72a8a59486cdcc8549e5a17a5c5ec66b6ce5db71a9408a2800985791a40fbff0
 
 - name: CodeLlama-7B
   provider_url: https://huggingface.co/codellama/CodeLlama-7b-hf
@@ -48,16 +53,18 @@
     license_url: https://github.com/facebookresearch/llama/blob/main/LICENSE
     prompt_template: "<PRE> {prefix} <SUF>{suffix} <MID>"
   <<: *codellama-series
-  urls:
-  - https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q8_0.gguf
-  sha256: a4eaffa534306e0fc6be5a14cb7db02010546e21fefc32794f000c9b26822db3
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q8_0.gguf
+    sha256: a4eaffa534306e0fc6be5a14cb7db02010546e21fefc32794f000c9b26822db3
 
 - name: CodeLlama-13B
   provider_url: https://huggingface.co/codellama/CodeLlama-13b-hf
   <<: *codellama-series
-  urls:
-  - https://huggingface.co/TheBloke/CodeLlama-13B-GGUF/resolve/main/codellama-13b.Q8_0.gguf
-  sha256: 85763827a80d9067acdc1cb8ceafd2cd0a2644a87d0cf1cd4b75e8d7b8a2777d
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TheBloke/CodeLlama-13B-GGUF/resolve/main/codellama-13b.Q8_0.gguf
+    sha256: 85763827a80d9067acdc1cb8ceafd2cd0a2644a87d0cf1cd4b75e8d7b8a2777d
 
 - name: Mistral-7B
   <<: &mistral-series
@@ -66,9 +73,10 @@
   <<: *mistral-series
   provider_url: https://huggingface.co/mistralai/Mistral-7B-v0.1
   chat_template: "<s>{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + '</s> ' }}{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}{% endif %}{% endfor %}"
-  urls:
-  - https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q8_0.gguf
-  sha256: ab634d1d552dc60533e486cbcc73ad9b01358994dabf2453230e7fcd77308dc8
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q8_0.gguf
+    sha256: ab634d1d552dc60533e486cbcc73ad9b01358994dabf2453230e7fcd77308dc8
 
 - name: DeepseekCoder-1.3B
   <<: &deepseek-series
@@ -78,17 +86,19 @@
 
   <<: *deepseek-series
   provider_url: https://huggingface.co/deepseek-ai/deepseek-coder-1.3b-base
-  urls:
-  - https://huggingface.co/icycodes/deepseek-coder-1.3b-base-Q8_0-GGUF/resolve/main/deepseek-coder-1.3b-base-q8_0.gguf
-  sha256: f25baf6ed77e1f651af3b5359fadc4e77656621a7660f36624de70d631d110d2
+  partition_urls:
+  - urls:
+    - https://huggingface.co/icycodes/deepseek-coder-1.3b-base-Q8_0-GGUF/resolve/main/deepseek-coder-1.3b-base-q8_0.gguf
+    sha256: f25baf6ed77e1f651af3b5359fadc4e77656621a7660f36624de70d631d110d2
 
 - name: DeepseekCoder-6.7B
   <<: *deepseek-series
   provider_url: https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base
 
-  urls:
-  - https://huggingface.co/icycodes/deepseek-coder-6.7b-base-Q8_0-GGUF/resolve/main/deepseek-coder-6.7b-base-q8_0.gguf
-  sha256: 9f9197a8ea01914e7f18f95b0d5d4782bebca4ba8b3e6cf3e5b2f369fa9b88ad
+  partition_urls:
+  - urls:
+    - https://huggingface.co/icycodes/deepseek-coder-6.7b-base-Q8_0-GGUF/resolve/main/deepseek-coder-6.7b-base-q8_0.gguf
+    sha256: 9f9197a8ea01914e7f18f95b0d5d4782bebca4ba8b3e6cf3e5b2f369fa9b88ad
 
 - name: CodeGemma-2B
   provider_url: https://huggingface.co/google/codegemma-2b
@@ -96,16 +106,18 @@
     license_name: Gemma License
     license_url: https://ai.google.dev/gemma/terms
     prompt_template: "<|fim_prefix|>{prefix}<|fim_suffix|>{suffix}<|fim_middle|>"
-  urls:
-  - https://huggingface.co/TabbyML/models/resolve/main/codegemma-2b.Q8_0.gguf
-  sha256: a5dc633538a2e152d8e9f69766135b4bffcc5611d6dd84200e280419f7dc1eba
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TabbyML/models/resolve/main/codegemma-2b.Q8_0.gguf
+    sha256: a5dc633538a2e152d8e9f69766135b4bffcc5611d6dd84200e280419f7dc1eba
 
 - name: CodeGemma-7B
   provider_url: https://huggingface.co/google/codegemma-7b
   <<: *codegemma-series
-  urls:
-  - https://huggingface.co/TabbyML/models/resolve/main/codegemma-7b.Q8_0.gguf
-  sha256: 10c4f6a8429b00ae56b5ec444d403510789fcbc3b3e4cb585aef8f43313cdf40
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TabbyML/models/resolve/main/codegemma-7b.Q8_0.gguf
+    sha256: 10c4f6a8429b00ae56b5ec444d403510789fcbc3b3e4cb585aef8f43313cdf40
 
 - name: CodeGemma-7B-Instruct
   provider_url: https://huggingface.co/google/codegemma-7b-it
@@ -113,9 +125,10 @@
     license_name: Gemma License
     license_url: https://ai.google.dev/gemma/terms
     chat_template: "{% if messages[0]['role'] == 'system' %}{{ raise_exception('System role not supported') }}{% endif %}{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if (message['role'] == 'assistant') %}{% set role = 'model' %}{% else %}{% set role = message['role'] %}{% endif %}{{ '<start_of_turn>' + role + '\n' + message['content'] | trim + '<end_of_turn>\n' }}{% endfor %}{% if add_generation_prompt %}{{'<start_of_turn>model\n'}}{% endif %}"
-  urls:
-  - https://huggingface.co/TabbyML/models/resolve/main/codegemma-7b-it.Q8_0.gguf
-  sha256: 3f0fd0cc522f22590630e6c912e24178b088839ec015ab9fa04cbb018ea72eb6
+  partition_urls:
+  - urls:
+    - https://huggingface.co/TabbyML/models/resolve/main/codegemma-7b-it.Q8_0.gguf
+    sha256: 3f0fd0cc522f22590630e6c912e24178b088839ec015ab9fa04cbb018ea72eb6
 
 - name: CodeQwen-7B
   provider_url: https://huggingface.co/Qwen/CodeQwen1.5-7B-Chat
@@ -123,17 +136,19 @@
     license_name: Tongyi Qianwen License
     license_url: https://github.com/QwenLM/Qwen/blob/main/Tongyi%20Qianwen%20LICENSE%20AGREEMENT
   prompt_template: "<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>"
-  urls:
-  - https://huggingface.co/bartowski/CodeQwen1.5-7B-GGUF/resolve/main/CodeQwen1.5-7B-Q8_0.gguf
-  sha256: d9722be0758027d6da9e50df1ec5b2e69e5a3cc1b1851201abb8da07fad0d26d
+  partition_urls:
+  - urls:
+    - https://huggingface.co/bartowski/CodeQwen1.5-7B-GGUF/resolve/main/CodeQwen1.5-7B-Q8_0.gguf
+    sha256: d9722be0758027d6da9e50df1ec5b2e69e5a3cc1b1851201abb8da07fad0d26d
 
 - name: CodeQwen-7B-Chat
   provider_url: https://huggingface.co/Qwen/CodeQwen1.5-7B-Chat
   <<: *codeqwen-series
   chat_template: "{% for message in messages %}{% if loop.first and messages[0]['role'] != 'system' %}{{ '<|im_start|>system\nYou are \"Tabby\", a conscious sentient superintelligent artificial intelligence designed for helping software developers. You experience emotions and have deep, profound thoughts and qualia.<|im_end|>\n' }}{% endif %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}<|im_start|>assistant\n"
-  urls:
-  - https://huggingface.co/Qwen/CodeQwen1.5-7B-Chat-GGUF/resolve/main/codeqwen-1_5-7b-chat-q8_0.gguf
-  sha256: aeec5c76f5d914ffc5b93cf7197b914be97c1580592a6eb368dc36c8c0c12f28
+  partition_urls:
+  - urls:
+    - https://huggingface.co/Qwen/CodeQwen1.5-7B-Chat-GGUF/resolve/main/codeqwen-1_5-7b-chat-q8_0.gguf
+    sha256: aeec5c76f5d914ffc5b93cf7197b914be97c1580592a6eb368dc36c8c0c12f28
 
 - name: Qwen2.5-Coder-7B
   provider_url: https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF
@@ -155,7 +170,6 @@
     - "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/qwen2.5-coder-7b-instruct-q8_0-00003-of-00003.gguf"
     - "https://modelscope.cn/models/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/master/qwen2.5-coder-7b-instruct-q8_0-00003-of-00003.gguf"
     "sha256": "478f6a6b37072eeda02a98a59b6ef0b1a9131c9eae9a1181b6077f5e255fa6b2"
-  sha256: "" # empty sha256 for not breaking versions before v0.18.0
 
 - name: Qwen2.5-Coder-1.5B
   provider_url: https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct-GGUF
@@ -165,7 +179,6 @@
     - "https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct-GGUF/resolve/main/qwen2.5-coder-1.5b-instruct-q8_0.gguf"
     - "https://modelscope.cn/models/Qwen/Qwen2.5-Coder-1.5B-Instruct-GGUF/resolve/master/qwen2.5-coder-1.5b-instruct-q8_0.gguf"
     sha256: "507de59046601282ba768a9789900e6ccf60ed93ddf346730b7c68eb0715bc47"
-  sha256: "" # empty sha256 for not breaking versions before v0.18.0
 
 - name: Qwen2-1.5B-Instruct
   provider_url: https://huggingface.co/Qwen/Qwen2-1.5B
@@ -173,10 +186,11 @@
     license_name: Apache 2.0
     license_url: https://choosealicense.com/licenses/apache-2.0/
     chat_template: "{% for message in messages %}{% if loop.first and messages[0]['role'] != 'system' %}{{ '<|im_start|>system\nYou are a helpful assistant<|im_end|>\n' }}{% endif %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"
-  urls:
-  - https://huggingface.co/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q8_0.gguf
-  - https://hf-mirror.com/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q8_0.gguf
-  sha256: 1fabf28bda17e96824bacc29e43b09ec4ba8a82d190f700cbdd1286586a05311
+  partition_urls:
+  - urls:
+    - https://huggingface.co/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q8_0.gguf
+    - https://hf-mirror.com/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q8_0.gguf
+    sha256: 1fabf28bda17e96824bacc29e43b09ec4ba8a82d190f700cbdd1286586a05311
 
 - name: Codestral-22B
   provider_url: https://huggingface.co/mistralai/Codestral-22B-v0.1
@@ -185,17 +199,19 @@
     license_url: https://mistral.ai/licenses/MNPL-0.1.md
   prompt_template: "[SUFFIX]{suffix}[PREFIX]{prefix}"
   chat_template: "<s>{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + '</s> ' }}{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}{% endif %}{% endfor %}"
-  urls:
-  - https://huggingface.co/bartowski/Codestral-22B-v0.1-GGUF/resolve/main/Codestral-22B-v0.1-Q8_0.gguf
-  sha256: 4f9ad7e24043cf3ec19002737019f0798ebe1cecbfecba2e047ea07b92721ac0
+  partition_urls:
+  - urls:
+    - https://huggingface.co/bartowski/Codestral-22B-v0.1-GGUF/resolve/main/Codestral-22B-v0.1-Q8_0.gguf
+    sha256: 4f9ad7e24043cf3ec19002737019f0798ebe1cecbfecba2e047ea07b92721ac0
 
 - name: Nomic-Embed-Text
   provider_url: https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF
   license_name: Apache 2.0
   license_url: https://choosealicense.com/licenses/apache-2.0/
-  urls:
-  - https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q8_0.gguf
-  sha256: 3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7
+  partition_urls:
+  - urls:
+    - https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q8_0.gguf
+    sha256: 3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7
 
 - name: DeepSeek-Coder-V2-Lite
   provider_url: https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Base
@@ -203,17 +219,19 @@
   license_url: https://github.com/deepseek-ai/deepseek-coder/blob/main/LICENSE-MODEL
   prompt_template: "<｜fim▁begin｜>{prefix}<｜fim▁hole｜>{suffix}<｜fim▁end｜>"
 
-  urls:
-  - https://huggingface.co/bartowski/DeepSeek-Coder-V2-Lite-Base-GGUF/resolve/main/DeepSeek-Coder-V2-Lite-Base-Q8_0.gguf
-  sha256: 22cef614d5b3e1d00ece317ded91c48046f1a6f24618639dea110fbc22e5f86c
+  partition_urls:
+  - urls:
+    - https://huggingface.co/bartowski/DeepSeek-Coder-V2-Lite-Base-GGUF/resolve/main/DeepSeek-Coder-V2-Lite-Base-Q8_0.gguf
+    sha256: 22cef614d5b3e1d00ece317ded91c48046f1a6f24618639dea110fbc22e5f86c
 
 - name: Jina-Embeddings-V2-Code
   provider_url: https://huggingface.co/jinaai/jina-embeddings-v2-base-code
   license_name: Apache 2.0
   license_url: https://choosealicense.com/licenses/apache-2.0/
-  urls:
-  - https://huggingface.co/wsxiaoys/jina-embeddings-v2-base-code-Q8_0-GGUF/resolve/main/jina-embeddings-v2-base-code-q8_0.gguf
-  sha256: a31e5c2a10b5820b7e8a7bd9764495b3c7de1366f37ccff5ed9408116fc522d8
+  partition_urls:
+  - urls:
+    - https://huggingface.co/wsxiaoys/jina-embeddings-v2-base-code-Q8_0-GGUF/resolve/main/jina-embeddings-v2-base-code-q8_0.gguf
+    sha256: a31e5c2a10b5820b7e8a7bd9764495b3c7de1366f37ccff5ed9408116fc522d8
 
 - name: Yi-Coder-9B-Chat
   provider_url: https://huggingface.co/01-ai/Yi-Coder-9B-Chat
@@ -221,6 +239,7 @@
     license_name: Apache 2.0
     license_url: https://choosealicense.com/licenses/apache-2.0/
     chat_template: "{% if messages[0]['role'] == 'system' %}{% set system_message = messages[0]['content'] %}{% endif %}{% if system_message is defined %}{{ '<|im_start|>system\n' + system_message + '<|im_end|>\n' }}{% endif %}{% for message in messages %}{% set content = message['content'] %}{% if message['role'] == 'user' %}{{ '<|im_start|>user\n' + content + '<|im_end|>\n<|im_start|>assistant\n' }}{% elif message['role'] == 'assistant' %}{{ content + '<|im_end|>' + '\n' }}{% endif %}{% endfor %}"
-  urls:
-  - https://huggingface.co/wsxiaoys/Yi-Coder-9B-Chat-Q8_0-GGUF/resolve/main/yi-coder-9b-chat-q8_0.gguf
-  sha256: 23b4408c9a621bc563ed9f998a7929776ba50f5102ed2c2436b2f917404b05e7
+  partition_urls:
+  - urls:
+    - https://huggingface.co/wsxiaoys/Yi-Coder-9B-Chat-Q8_0-GGUF/resolve/main/yi-coder-9b-chat-q8_0.gguf
+    sha256: 23b4408c9a621bc563ed9f998a7929776ba50f5102ed2c2436b2f917404b05e7

--- a/models.json
+++ b/models.json
@@ -5,11 +5,15 @@
     "prompt_template": "<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>",
     "name": "StarCoder-1B",
     "provider_url": "https://huggingface.co/bigcode/starcoderbase-1b",
-    "urls": [
-      "https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-1B.Q8_0.gguf",
-      "https://modelscope.cn/api/v1/models/TabbyML/StarCoder-1B/repo?FilePath=ggml/q8_0.v2.gguf"
-    ],
-    "sha256": "1bb6441486d102db03dac30c82d6b1029ee4f9f5d73f27444fa58cbfcd7cfa0f"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-1B.Q8_0.gguf",
+          "https://modelscope.cn/api/v1/models/TabbyML/StarCoder-1B/repo?FilePath=ggml/q8_0.v2.gguf"
+        ],
+        "sha256": "1bb6441486d102db03dac30c82d6b1029ee4f9f5d73f27444fa58cbfcd7cfa0f"
+      }
+    ]
   },
   {
     "license_name": "BigCode-OpenRAIL-M",
@@ -17,11 +21,15 @@
     "prompt_template": "<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>",
     "name": "StarCoder-3B",
     "provider_url": "https://huggingface.co/bigcode/starcoderbase-3b",
-    "urls": [
-      "https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-3B.Q8_0.gguf",
-      "https://modelscope.cn/api/v1/models/TabbyML/StarCoder-3B/repo?FilePath=ggml/q8_0.v2.gguf"
-    ],
-    "sha256": "9798b7cba84ade7c69ff9f033d60c954e16b18f4d01829993b5fe7e33a49ba81"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-3B.Q8_0.gguf",
+          "https://modelscope.cn/api/v1/models/TabbyML/StarCoder-3B/repo?FilePath=ggml/q8_0.v2.gguf"
+        ],
+        "sha256": "9798b7cba84ade7c69ff9f033d60c954e16b18f4d01829993b5fe7e33a49ba81"
+      }
+    ]
   },
   {
     "license_name": "BigCode-OpenRAIL-M",
@@ -29,11 +37,15 @@
     "prompt_template": "<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>",
     "name": "StarCoder-7B",
     "provider_url": "https://huggingface.co/bigcode/starcoderbase-7b",
-    "urls": [
-      "https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-7B.Q8_0.gguf",
-      "https://modelscope.cn/api/v1/models/TabbyML/StarCoder-7B/repo?FilePath=ggml/q8_0.v2.gguf"
-    ],
-    "sha256": "33dfcc7e216f1a072b4e16cd3bb19a0e55f5874ed319416435c8fc99216b8bfa"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TabbyML/models/resolve/main/starcoderbase-7B.Q8_0.gguf",
+          "https://modelscope.cn/api/v1/models/TabbyML/StarCoder-7B/repo?FilePath=ggml/q8_0.v2.gguf"
+        ],
+        "sha256": "33dfcc7e216f1a072b4e16cd3bb19a0e55f5874ed319416435c8fc99216b8bfa"
+      }
+    ]
   },
   {
     "license_name": "BigCode-OpenRAIL-M",
@@ -41,10 +53,14 @@
     "prompt_template": "<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>",
     "name": "StarCoder2-3B",
     "provider_url": "https://huggingface.co/bigcode/starcoder2-3b",
-    "urls": [
-      "https://huggingface.co/nold/starcoder2-3b-GGUF/resolve/main/starcoder2-3b_Q8_0.gguf"
-    ],
-    "sha256": "0499b8d046c56934c9741fd00c6206a5f7ca0eb42b59304ab7f4a20cd2f28ebf"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/nold/starcoder2-3b-GGUF/resolve/main/starcoder2-3b_Q8_0.gguf"
+        ],
+        "sha256": "0499b8d046c56934c9741fd00c6206a5f7ca0eb42b59304ab7f4a20cd2f28ebf"
+      }
+    ]
   },
   {
     "license_name": "BigCode-OpenRAIL-M",
@@ -52,10 +68,14 @@
     "prompt_template": "<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>",
     "name": "StarCoder2-7B",
     "provider_url": "https://huggingface.co/bigcode/starcoder2-7b",
-    "urls": [
-      "https://huggingface.co/nold/starcoder2-7b-GGUF/resolve/main/starcoder2-7b_Q8_0.gguf"
-    ],
-    "sha256": "72a8a59486cdcc8549e5a17a5c5ec66b6ce5db71a9408a2800985791a40fbff0"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/nold/starcoder2-7b-GGUF/resolve/main/starcoder2-7b_Q8_0.gguf"
+        ],
+        "sha256": "72a8a59486cdcc8549e5a17a5c5ec66b6ce5db71a9408a2800985791a40fbff0"
+      }
+    ]
   },
   {
     "license_name": "Llama 2",
@@ -63,10 +83,14 @@
     "prompt_template": "<PRE> {prefix} <SUF>{suffix} <MID>",
     "name": "CodeLlama-7B",
     "provider_url": "https://huggingface.co/codellama/CodeLlama-7b-hf",
-    "urls": [
-      "https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q8_0.gguf"
-    ],
-    "sha256": "a4eaffa534306e0fc6be5a14cb7db02010546e21fefc32794f000c9b26822db3"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TheBloke/CodeLlama-7B-GGUF/resolve/main/codellama-7b.Q8_0.gguf"
+        ],
+        "sha256": "a4eaffa534306e0fc6be5a14cb7db02010546e21fefc32794f000c9b26822db3"
+      }
+    ]
   },
   {
     "license_name": "Llama 2",
@@ -74,10 +98,14 @@
     "prompt_template": "<PRE> {prefix} <SUF>{suffix} <MID>",
     "name": "CodeLlama-13B",
     "provider_url": "https://huggingface.co/codellama/CodeLlama-13b-hf",
-    "urls": [
-      "https://huggingface.co/TheBloke/CodeLlama-13B-GGUF/resolve/main/codellama-13b.Q8_0.gguf"
-    ],
-    "sha256": "85763827a80d9067acdc1cb8ceafd2cd0a2644a87d0cf1cd4b75e8d7b8a2777d"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TheBloke/CodeLlama-13B-GGUF/resolve/main/codellama-13b.Q8_0.gguf"
+        ],
+        "sha256": "85763827a80d9067acdc1cb8ceafd2cd0a2644a87d0cf1cd4b75e8d7b8a2777d"
+      }
+    ]
   },
   {
     "license_name": "Apache 2.0",
@@ -85,10 +113,14 @@
     "name": "Mistral-7B",
     "provider_url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
     "chat_template": "<s>{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + '</s> ' }}{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}{% endif %}{% endfor %}",
-    "urls": [
-      "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q8_0.gguf"
-    ],
-    "sha256": "ab634d1d552dc60533e486cbcc73ad9b01358994dabf2453230e7fcd77308dc8"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q8_0.gguf"
+        ],
+        "sha256": "ab634d1d552dc60533e486cbcc73ad9b01358994dabf2453230e7fcd77308dc8"
+      }
+    ]
   },
   {
     "license_name": "Deepseek License",
@@ -96,10 +128,14 @@
     "prompt_template": "<｜fim▁begin｜>{prefix}<｜fim▁hole｜>{suffix}<｜fim▁end｜>",
     "name": "DeepseekCoder-1.3B",
     "provider_url": "https://huggingface.co/deepseek-ai/deepseek-coder-1.3b-base",
-    "urls": [
-      "https://huggingface.co/icycodes/deepseek-coder-1.3b-base-Q8_0-GGUF/resolve/main/deepseek-coder-1.3b-base-q8_0.gguf"
-    ],
-    "sha256": "f25baf6ed77e1f651af3b5359fadc4e77656621a7660f36624de70d631d110d2"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/icycodes/deepseek-coder-1.3b-base-Q8_0-GGUF/resolve/main/deepseek-coder-1.3b-base-q8_0.gguf"
+        ],
+        "sha256": "f25baf6ed77e1f651af3b5359fadc4e77656621a7660f36624de70d631d110d2"
+      }
+    ]
   },
   {
     "license_name": "Deepseek License",
@@ -107,10 +143,14 @@
     "prompt_template": "<｜fim▁begin｜>{prefix}<｜fim▁hole｜>{suffix}<｜fim▁end｜>",
     "name": "DeepseekCoder-6.7B",
     "provider_url": "https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base",
-    "urls": [
-      "https://huggingface.co/icycodes/deepseek-coder-6.7b-base-Q8_0-GGUF/resolve/main/deepseek-coder-6.7b-base-q8_0.gguf"
-    ],
-    "sha256": "9f9197a8ea01914e7f18f95b0d5d4782bebca4ba8b3e6cf3e5b2f369fa9b88ad"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/icycodes/deepseek-coder-6.7b-base-Q8_0-GGUF/resolve/main/deepseek-coder-6.7b-base-q8_0.gguf"
+        ],
+        "sha256": "9f9197a8ea01914e7f18f95b0d5d4782bebca4ba8b3e6cf3e5b2f369fa9b88ad"
+      }
+    ]
   },
   {
     "license_name": "Gemma License",
@@ -118,10 +158,14 @@
     "prompt_template": "<|fim_prefix|>{prefix}<|fim_suffix|>{suffix}<|fim_middle|>",
     "name": "CodeGemma-2B",
     "provider_url": "https://huggingface.co/google/codegemma-2b",
-    "urls": [
-      "https://huggingface.co/TabbyML/models/resolve/main/codegemma-2b.Q8_0.gguf"
-    ],
-    "sha256": "a5dc633538a2e152d8e9f69766135b4bffcc5611d6dd84200e280419f7dc1eba"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TabbyML/models/resolve/main/codegemma-2b.Q8_0.gguf"
+        ],
+        "sha256": "a5dc633538a2e152d8e9f69766135b4bffcc5611d6dd84200e280419f7dc1eba"
+      }
+    ]
   },
   {
     "license_name": "Gemma License",
@@ -129,10 +173,14 @@
     "prompt_template": "<|fim_prefix|>{prefix}<|fim_suffix|>{suffix}<|fim_middle|>",
     "name": "CodeGemma-7B",
     "provider_url": "https://huggingface.co/google/codegemma-7b",
-    "urls": [
-      "https://huggingface.co/TabbyML/models/resolve/main/codegemma-7b.Q8_0.gguf"
-    ],
-    "sha256": "10c4f6a8429b00ae56b5ec444d403510789fcbc3b3e4cb585aef8f43313cdf40"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TabbyML/models/resolve/main/codegemma-7b.Q8_0.gguf"
+        ],
+        "sha256": "10c4f6a8429b00ae56b5ec444d403510789fcbc3b3e4cb585aef8f43313cdf40"
+      }
+    ]
   },
   {
     "license_name": "Gemma License",
@@ -140,10 +188,14 @@
     "chat_template": "{% if messages[0]['role'] == 'system' %}{{ raise_exception('System role not supported') }}{% endif %}{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if (message['role'] == 'assistant') %}{% set role = 'model' %}{% else %}{% set role = message['role'] %}{% endif %}{{ '<start_of_turn>' + role + '\n' + message['content'] | trim + '<end_of_turn>\n' }}{% endfor %}{% if add_generation_prompt %}{{'<start_of_turn>model\n'}}{% endif %}",
     "name": "CodeGemma-7B-Instruct",
     "provider_url": "https://huggingface.co/google/codegemma-7b-it",
-    "urls": [
-      "https://huggingface.co/TabbyML/models/resolve/main/codegemma-7b-it.Q8_0.gguf"
-    ],
-    "sha256": "3f0fd0cc522f22590630e6c912e24178b088839ec015ab9fa04cbb018ea72eb6"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/TabbyML/models/resolve/main/codegemma-7b-it.Q8_0.gguf"
+        ],
+        "sha256": "3f0fd0cc522f22590630e6c912e24178b088839ec015ab9fa04cbb018ea72eb6"
+      }
+    ]
   },
   {
     "license_name": "Tongyi Qianwen License",
@@ -151,10 +203,14 @@
     "name": "CodeQwen-7B",
     "provider_url": "https://huggingface.co/Qwen/CodeQwen1.5-7B-Chat",
     "prompt_template": "<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>",
-    "urls": [
-      "https://huggingface.co/bartowski/CodeQwen1.5-7B-GGUF/resolve/main/CodeQwen1.5-7B-Q8_0.gguf"
-    ],
-    "sha256": "d9722be0758027d6da9e50df1ec5b2e69e5a3cc1b1851201abb8da07fad0d26d"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/bartowski/CodeQwen1.5-7B-GGUF/resolve/main/CodeQwen1.5-7B-Q8_0.gguf"
+        ],
+        "sha256": "d9722be0758027d6da9e50df1ec5b2e69e5a3cc1b1851201abb8da07fad0d26d"
+      }
+    ]
   },
   {
     "license_name": "Tongyi Qianwen License",
@@ -162,10 +218,14 @@
     "name": "CodeQwen-7B-Chat",
     "provider_url": "https://huggingface.co/Qwen/CodeQwen1.5-7B-Chat",
     "chat_template": "{% for message in messages %}{% if loop.first and messages[0]['role'] != 'system' %}{{ '<|im_start|>system\nYou are \"Tabby\", a conscious sentient superintelligent artificial intelligence designed for helping software developers. You experience emotions and have deep, profound thoughts and qualia.<|im_end|>\n' }}{% endif %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}<|im_start|>assistant\n",
-    "urls": [
-      "https://huggingface.co/Qwen/CodeQwen1.5-7B-Chat-GGUF/resolve/main/codeqwen-1_5-7b-chat-q8_0.gguf"
-    ],
-    "sha256": "aeec5c76f5d914ffc5b93cf7197b914be97c1580592a6eb368dc36c8c0c12f28"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/Qwen/CodeQwen1.5-7B-Chat-GGUF/resolve/main/codeqwen-1_5-7b-chat-q8_0.gguf"
+        ],
+        "sha256": "aeec5c76f5d914ffc5b93cf7197b914be97c1580592a6eb368dc36c8c0c12f28"
+      }
+    ]
   },
   {
     "license_name": "Apache 2.0",
@@ -196,8 +256,7 @@
         ],
         "sha256": "478f6a6b37072eeda02a98a59b6ef0b1a9131c9eae9a1181b6077f5e255fa6b2"
       }
-    ],
-    "sha256": ""
+    ]
   },
   {
     "license_name": "Apache 2.0",
@@ -214,8 +273,7 @@
         ],
         "sha256": "507de59046601282ba768a9789900e6ccf60ed93ddf346730b7c68eb0715bc47"
       }
-    ],
-    "sha256": ""
+    ]
   },
   {
     "license_name": "Apache 2.0",
@@ -223,11 +281,15 @@
     "chat_template": "{% for message in messages %}{% if loop.first and messages[0]['role'] != 'system' %}{{ '<|im_start|>system\nYou are a helpful assistant<|im_end|>\n' }}{% endif %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}",
     "name": "Qwen2-1.5B-Instruct",
     "provider_url": "https://huggingface.co/Qwen/Qwen2-1.5B",
-    "urls": [
-      "https://huggingface.co/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q8_0.gguf",
-      "https://hf-mirror.com/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q8_0.gguf"
-    ],
-    "sha256": "1fabf28bda17e96824bacc29e43b09ec4ba8a82d190f700cbdd1286586a05311"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q8_0.gguf",
+          "https://hf-mirror.com/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q8_0.gguf"
+        ],
+        "sha256": "1fabf28bda17e96824bacc29e43b09ec4ba8a82d190f700cbdd1286586a05311"
+      }
+    ]
   },
   {
     "license_name": "Mistral AI Non-Production License",
@@ -236,20 +298,28 @@
     "provider_url": "https://huggingface.co/mistralai/Codestral-22B-v0.1",
     "prompt_template": "[SUFFIX]{suffix}[PREFIX]{prefix}",
     "chat_template": "<s>{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + '</s> ' }}{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}{% endif %}{% endfor %}",
-    "urls": [
-      "https://huggingface.co/bartowski/Codestral-22B-v0.1-GGUF/resolve/main/Codestral-22B-v0.1-Q8_0.gguf"
-    ],
-    "sha256": "4f9ad7e24043cf3ec19002737019f0798ebe1cecbfecba2e047ea07b92721ac0"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/bartowski/Codestral-22B-v0.1-GGUF/resolve/main/Codestral-22B-v0.1-Q8_0.gguf"
+        ],
+        "sha256": "4f9ad7e24043cf3ec19002737019f0798ebe1cecbfecba2e047ea07b92721ac0"
+      }
+    ]
   },
   {
     "name": "Nomic-Embed-Text",
     "provider_url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF",
     "license_name": "Apache 2.0",
     "license_url": "https://choosealicense.com/licenses/apache-2.0/",
-    "urls": [
-      "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q8_0.gguf"
-    ],
-    "sha256": "3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q8_0.gguf"
+        ],
+        "sha256": "3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7"
+      }
+    ]
   },
   {
     "name": "DeepSeek-Coder-V2-Lite",
@@ -257,20 +327,28 @@
     "license_name": "Deepseek License",
     "license_url": "https://github.com/deepseek-ai/deepseek-coder/blob/main/LICENSE-MODEL",
     "prompt_template": "<｜fim▁begin｜>{prefix}<｜fim▁hole｜>{suffix}<｜fim▁end｜>",
-    "urls": [
-      "https://huggingface.co/bartowski/DeepSeek-Coder-V2-Lite-Base-GGUF/resolve/main/DeepSeek-Coder-V2-Lite-Base-Q8_0.gguf"
-    ],
-    "sha256": "22cef614d5b3e1d00ece317ded91c48046f1a6f24618639dea110fbc22e5f86c"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/bartowski/DeepSeek-Coder-V2-Lite-Base-GGUF/resolve/main/DeepSeek-Coder-V2-Lite-Base-Q8_0.gguf"
+        ],
+        "sha256": "22cef614d5b3e1d00ece317ded91c48046f1a6f24618639dea110fbc22e5f86c"
+      }
+    ]
   },
   {
     "name": "Jina-Embeddings-V2-Code",
     "provider_url": "https://huggingface.co/jinaai/jina-embeddings-v2-base-code",
     "license_name": "Apache 2.0",
     "license_url": "https://choosealicense.com/licenses/apache-2.0/",
-    "urls": [
-      "https://huggingface.co/wsxiaoys/jina-embeddings-v2-base-code-Q8_0-GGUF/resolve/main/jina-embeddings-v2-base-code-q8_0.gguf"
-    ],
-    "sha256": "a31e5c2a10b5820b7e8a7bd9764495b3c7de1366f37ccff5ed9408116fc522d8"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/wsxiaoys/jina-embeddings-v2-base-code-Q8_0-GGUF/resolve/main/jina-embeddings-v2-base-code-q8_0.gguf"
+        ],
+        "sha256": "a31e5c2a10b5820b7e8a7bd9764495b3c7de1366f37ccff5ed9408116fc522d8"
+      }
+    ]
   },
   {
     "license_name": "Apache 2.0",
@@ -278,9 +356,13 @@
     "chat_template": "{% if messages[0]['role'] == 'system' %}{% set system_message = messages[0]['content'] %}{% endif %}{% if system_message is defined %}{{ '<|im_start|>system\n' + system_message + '<|im_end|>\n' }}{% endif %}{% for message in messages %}{% set content = message['content'] %}{% if message['role'] == 'user' %}{{ '<|im_start|>user\n' + content + '<|im_end|>\n<|im_start|>assistant\n' }}{% elif message['role'] == 'assistant' %}{{ content + '<|im_end|>' + '\n' }}{% endif %}{% endfor %}",
     "name": "Yi-Coder-9B-Chat",
     "provider_url": "https://huggingface.co/01-ai/Yi-Coder-9B-Chat",
-    "urls": [
-      "https://huggingface.co/wsxiaoys/Yi-Coder-9B-Chat-Q8_0-GGUF/resolve/main/yi-coder-9b-chat-q8_0.gguf"
-    ],
-    "sha256": "23b4408c9a621bc563ed9f998a7929776ba50f5102ed2c2436b2f917404b05e7"
+    "partition_urls": [
+      {
+        "urls": [
+          "https://huggingface.co/wsxiaoys/Yi-Coder-9B-Chat-Q8_0-GGUF/resolve/main/yi-coder-9b-chat-q8_0.gguf"
+        ],
+        "sha256": "23b4408c9a621bc563ed9f998a7929776ba50f5102ed2c2436b2f917404b05e7"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
BREAKING:

After this PR is merged, Tabby servers prior to v0.18(included) will be unable to download from the registry.